### PR TITLE
fix: Fix typos in question_rephrasing_prompt.py

### DIFF
--- a/rag-core-api/src/rag_core_api/prompt_templates/question_rephrasing_prompt.py
+++ b/rag-core-api/src/rag_core_api/prompt_templates/question_rephrasing_prompt.py
@@ -1,6 +1,6 @@
 QUESTION_REPHRASING_PROMPT = """<|begin_of_text|><|start_header_id|>system<|end_header_id|>
 
-Formuliere die folgende Frage neu. Benutze hiefür relevanten Kontext aus der History. Antworte auf Detusch.<|eot_id|><|start_header_id|>user<|end_header_id|>
+Formuliere die folgende Frage neu. Benutze hierfür relevanten Kontext aus der History. Antworte auf Deutsch.<|eot_id|><|start_header_id|>user<|end_header_id|>
 
 Question: {question}
 ChatHistory: {history}


### PR DESCRIPTION
## Description

Fix two typos in the question rephrasing prompt.

## Issue

None.

## Dependencies

Not applicable.
