### PR TITLE
fix: deletion issue for xml, docx and pptx files from qdrant

### DIFF
--- a/extractor-api-lib/src/extractor_api_lib/impl/extractors/file_extractors/ms_docs_extractor.py
+++ b/extractor-api-lib/src/extractor_api_lib/impl/extractors/file_extractors/ms_docs_extractor.py
@@ -92,7 +92,7 @@ class MSDocsExtractor(InformationFileExtractor):
             infer_table_structure=True,
         )
 
-        return self._process_elements(elements, file_path.name)
+        return self._process_elements(elements, name)
 
     def _process_elements(self, elements: list[Element], document_name: str) -> list[InternalInformationPiece]:
         processed_elements: list[InternalInformationPiece] = []

--- a/extractor-api-lib/src/extractor_api_lib/impl/extractors/file_extractors/xml_extractor.py
+++ b/extractor-api-lib/src/extractor_api_lib/impl/extractors/file_extractors/xml_extractor.py
@@ -61,7 +61,7 @@ class XMLExtractor(InformationFileExtractor):
             A list of processed information pieces extracted from the XML file.
         """
         elements = partition_xml(filename=file_path.as_posix(), xml_keep_tags=False)
-        return self._process_elements(elements, file_path.name)
+        return self._process_elements(elements, name)
 
     def _process_elements(self, elements: list[Element], document_name: str) -> list[InternalInformationPiece]:
         processed_elements: list[InternalInformationPiece] = []


### PR DESCRIPTION
This pull request includes a small but important change to improve code consistency in the `aextract_content` method across multiple file extractors. The change modifies the method to use the `name` parameter instead of `file_path.name` when passing the document name to `_process_elements`.