### PR TITLE
chore: allow additional requests_kwargs parameter in sitemap loader

### DIFF
--- a/extractor-api-lib/src/extractor_api_lib/impl/extractors/sitemap_extractor.py
+++ b/extractor-api-lib/src/extractor_api_lib/impl/extractors/sitemap_extractor.py
@@ -107,7 +107,7 @@ class SitemapExtractor(InformationExtractor):
         """
         sitemap_loader_parameters = {}
         for x in extraction_parameters.kwargs:
-            if x.key == "header_template":
+            if x.key == "header_template" or x.key == "requests_kwargs":
                 try:
                     sitemap_loader_parameters[x.key] = json.loads(x.value)
                 except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
This pull request includes a small change to the `_parse_sitemap_loader_parameters` method in `sitemap_extractor.py`. The change allows the method to handle an additional parameter, `requests_kwargs`, alongside `header_template`.